### PR TITLE
fix for external monitor

### DIFF
--- a/brightness.sh
+++ b/brightness.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-CURRBRIGHT=$(xrandr --current --verbose | grep 'Brightness:' | cut -f2- -d:)
+CURRBRIGHT=$(xrandr --current --verbose | grep -m 1 'Brightness:' | cut -f2- -d:)
 if [ "$1" = "+" ] && [ $(echo "$CURRBRIGHT < 1" | bc) -eq 1 ] 
 then
 xrandr --output $2 --brightness $(echo "$CURRBRIGHT + 0.1" | bc)


### PR DESCRIPTION
changed "grep" --> "grep -m 1" in order to return only the first match. The modification prevent the script to fail when you have plugged in an external monitor. Otherwise, when you have an additional display connected, grep return two (or more) lines with the brightnesses of the two displays (external and the laptop's one).