### PR TITLE
speed increase using stdbuf / grep -m1

### DIFF
--- a/brightness.sh
+++ b/brightness.sh
@@ -58,7 +58,7 @@ get_brightness() {
 list_displays() {
     echo 'displays:'
     displist=''
-    connected=$(stdbuf -o0 xrandr | grep -w connected | cut -f1 -d' ')
+    connected=$(xrandr | grep -w connected | cut -f1 -d' ')
     for display in $connected; do
         brightness=$(get_brightness "$display")
         gamma=$(get_gamma "$display")

--- a/brightness.sh
+++ b/brightness.sh
@@ -2,7 +2,7 @@
 set -e
 
 get_display_info() {
-    stdbuf -o0 xrandr --verbose | grep -m 1 -w "$1 connected" -A8 | grep "$2" | cut -f2- -d: | tr -d ' '
+    xrandr --verbose | grep -m 1 -w "$1 connected" -A8 | grep "$2" | cut -f2- -d: | tr -d ' '
 }
 
 # cribbed from redshift, https://github.com/jonls/redshift/blob/master/README-colorramp

--- a/brightness.sh
+++ b/brightness.sh
@@ -2,7 +2,7 @@
 set -e
 
 get_display_info() {
-    xrandr --verbose | grep -w "$1 connected" -A8 | grep "$2" | cut -f2- -d: | tr -d ' '
+    stdbuf -o0 xrandr --verbose | grep -m 1 -w "$1 connected" -A8 | grep "$2" | cut -f2- -d: | tr -d ' '
 }
 
 # cribbed from redshift, https://github.com/jonls/redshift/blob/master/README-colorramp
@@ -58,7 +58,7 @@ get_brightness() {
 list_displays() {
     echo 'displays:'
     displist=''
-    connected=$(xrandr | grep -w connected | cut -f1 -d' ')
+    connected=$(stdbuf -o0 xrandr | grep -w connected | cut -f1 -d' ')
     for display in $connected; do
         brightness=$(get_brightness "$display")
         gamma=$(get_gamma "$display")


### PR DESCRIPTION
As advised [here](https://unix.stackexchange.com/a/150823/250288), we can get some performance increase by

1. using `grep`'s `-m` flag to stop reading after a match ;
2. using `stdbuf` (part of GNU coreutils) to adjust the size of xrandr's stdout buffer.

For more information about `stdbuf`, see "[stdio input buffering problems](http://www.pixelbeat.org/programming/stdio_buffering/)" by Pádraig Brady (GNU coreutils maintainer).